### PR TITLE
Removing none to unset PRIVATE_KEY

### DIFF
--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -27,7 +27,7 @@ our app with the latest changes.
 ```
 docker run  -it --rm \
             -e APP_ID=abc \
-            -e PRIVATE_KEY=none \
+            -e PRIVATE_KEY= \
             -w /home/node/probot-hello-dev \
             -v "$(pwd)":/home/node/probot-hello-dev \
             -p 3000:3000 probot-hello \


### PR DESCRIPTION
Hi Folks, thanks to one of our learners, they reported an issue when running probot-hello in the `Develop locally` section. It was producing the error:
```
Error: The contents of `PRIVATE_KEY` could not be validated. Please check to ensure you have copied the contents of the .pem file correctly.
    at findPrivateKey (/home/node/probot-hello-dev/node_modules/probot/lib/private-key.js:37:15)
```

Turns out that setting PRIVATE_KEY to none no longer resolves to a false statement in probot lib's check for a private key. Instead we can now simply set the environment value to an empty value and have it processed properly in the probot lib to check for no private key and skip that check for local dev.

Apologies if this slowed anyone down.